### PR TITLE
feat: declare script globals as an array of {path, name} tables

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -4,5 +4,6 @@
     [modules.bootstrap]
         # bootstrap's UMD build does not self-register window.bootstrap when bundled
         # by esbuild; expose it explicitly so Hinode's scripts pipeline registers it.
-        [modules.bootstrap.globals]
-            "js/modules/bootstrap/bootstrap.bundle.js" = "bootstrap"
+        [[modules.bootstrap.globals]]
+            path = "js/modules/bootstrap/bootstrap.bundle.js"
+            name = "bootstrap"


### PR DESCRIPTION
## Summary

Migrates the declared script-globals from a path-keyed **map** to the **array-of-tables** form `[[...globals]]` with `path` + `name`, matching the case-preserving globals convention (Hugo lowercases TOML config keys, so path-keyed maps break for capitalized bundle filenames). This module's bundle name is lowercase so it was never broken, but the convention is moving uniformly across the ecosystem. Same window registration, new schema.

## Requires

Hinode with the array-of-tables globals reader (v3.10.0+, from hinode#2064). That reader also still accepts the legacy map form, so older hinode keeps working with the prior release of this module.

## Verification

Part of the coordinated globals-convention change; proven end-to-end on infusal.io (array-format gsap + map-format modules coexist under the backward-compatible reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)